### PR TITLE
Fixed: Failure in bw test

### DIFF
--- a/items.py
+++ b/items.py
@@ -677,7 +677,7 @@ for site, site_config in check_mk_config.get('sites', {}).items():
             },
         }
 
-        for server in site_config.get('livestatus_server'):
+        for server in site_config.get('livestatus_server', {}):
             multisites['{}_on_{}'.format(server.get('site', ''), server.get('name', '').replace('.', '_'))] = {
                 'status_host': None,
                 'user_sync': 'all',

--- a/metadata.py
+++ b/metadata.py
@@ -125,6 +125,9 @@ def find_hosts_to_monitor(metadata):
 
 @metadata_reactor
 def add_iptables_rules(metadata):
+    if not node.has_bundle("iptables"):
+        raise DoNotRunAgain
+
     interfaces = [metadata.get('main_interface'), ]
     interfaces += metadata.get('check_mk/additional_interfaces', [])
 


### PR DESCRIPTION
Fixed failures in bw test execution, when there is no `livestatus_server` or `iptables` bundle isn't present.